### PR TITLE
feature/hpc-stack - additional modulefiles

### DIFF
--- a/modulefiles/cheyenne.gnu/fv3
+++ b/modulefiles/cheyenne.gnu/fv3
@@ -19,8 +19,8 @@ module load mpt/2.22
 module load ncarcompilers/0.5.0
 module unload netcdf
 
-module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-nco-20201113/modulefiles/stack
-module load hpc/1.0.0-beta1
+module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.1.0/modulefiles/stack
+module load hpc/1.1.0
 module load hpc-gnu/9.1.0
 module load hpc-mpt/2.22
 

--- a/modulefiles/cheyenne.gnu/fv3_debug
+++ b/modulefiles/cheyenne.gnu/fv3_debug
@@ -19,8 +19,8 @@ module load mpt/2.22
 module load ncarcompilers/0.5.0
 module unload netcdf
 
-module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-nco-20201113/modulefiles/stack
-module load hpc/1.0.0-beta1
+module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.1.0/modulefiles/stack
+module load hpc/1.1.0
 module load hpc-gnu/9.1.0
 module load hpc-mpt/2.22
 

--- a/modulefiles/cheyenne.intel/fv3
+++ b/modulefiles/cheyenne.intel/fv3
@@ -19,8 +19,8 @@ module load mpt/2.22
 module load ncarcompilers/0.5.0
 module unload netcdf
 
-module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-nco-20201113/modulefiles/stack
-module load hpc/1.0.0-beta1
+module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.1.0/modulefiles/stack
+module load hpc/1.1.0
 module load hpc-intel/19.1.1
 module load hpc-mpt/2.22
 

--- a/modulefiles/cheyenne.intel/fv3_debug
+++ b/modulefiles/cheyenne.intel/fv3_debug
@@ -19,8 +19,8 @@ module load mpt/2.22
 module load ncarcompilers/0.5.0
 module unload netcdf
 
-module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-nco-20201113/modulefiles/stack
-module load hpc/1.0.0-beta1
+module use /glade/p/ral/jntp/GMTB/tools/hpc-stack-v1.1.0/modulefiles/stack
+module load hpc/1.1.0
 module load hpc-intel/19.1.1
 module load hpc-mpt/2.22
 

--- a/modulefiles/gaea.intel/fv3_debug
+++ b/modulefiles/gaea.intel/fv3_debug
@@ -33,7 +33,7 @@ module load png/1.6.35
 module load hdf5/1.10.6
 module load netcdf/4.7.4
 module load pio/2.5.1
-module load esmf/8_1_0_beta_snapshot_27
+module load esmf/8_1_0_beta_snapshot_27-debug
 
 module load bacio/2.4.1
 module load crtm/2.3.0


### PR DESCRIPTION
gaea.intel, cheyenne.intel, cheyenne.gnu - all regression tests pass against current baseline